### PR TITLE
Add hotkey to hide foreground elements

### DIFF
--- a/Source/BindableFunctions.cs
+++ b/Source/BindableFunctions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using UnityEngine;

--- a/Source/BindableFunctions.cs
+++ b/Source/BindableFunctions.cs
@@ -238,6 +238,63 @@ namespace DebugMod
             }
         }
 
+        [BindableMethod(name = "Take Screenshot", category = "Visual")]
+        public static void TakeScreenshot()
+        {
+            try
+            {
+                var dirName = Application.persistentDataPath + System.IO.Path.DirectorySeparatorChar + "screenshots";
+                System.IO.Directory.CreateDirectory(dirName);
+                var imageFilename = dirName + System.IO.Path.DirectorySeparatorChar + $"screenshot{DateTime.Now.ToFileTimeUtc()}.png";
+
+                ScreenCapture.CaptureScreenshot(imageFilename);
+            }
+            catch (Exception e)
+            {
+                Console.AddLine("Error while attempting to take screenshot, check ModLog.txt");
+                DebugMod.instance.Log("Error while attempting to take screenshot:\n" + e);
+            }
+        }
+
+        [BindableMethod(name = "Hide Foreground Elements", category = "Visual")]
+        public static void HideForegroundElements()
+        {
+            var scene = UnityEngine.SceneManagement.SceneManager
+                .GetSceneByName(DebugMod.GetSceneName());
+            GameObject[] rootGameObjects = scene.GetRootGameObjects();
+            if (rootGameObjects != null)
+            {
+                foreach (GameObject gameObject in rootGameObjects)
+                {
+                    HideUnwantedElementsInTree(gameObject.transform);
+                }
+            }
+        }
+
+        private static void HideUnwantedElementsInTree(Transform transform)
+        {
+            var go = transform.gameObject;
+            var zPos = transform.GetPositionZ();
+            if (zPos <= -3) // If object is a decorative foreground element
+                Hide(go);
+
+            foreach (Transform child in transform)
+            {
+                HideUnwantedElementsInTree(child);
+            }
+        }
+
+        private static void Hide(GameObject gameObject)
+        {
+            var spriteRenderer = gameObject.GetComponent<SpriteRenderer>();
+            if (spriteRenderer != null)
+            {
+                var color = spriteRenderer.color;
+                color.a = 0;
+                spriteRenderer.color = color;
+            }
+        }
+
         #endregion
 
         #region Panels

--- a/Source/BindableFunctions.cs
+++ b/Source/BindableFunctions.cs
@@ -474,7 +474,7 @@ namespace DebugMod
             if (DebugMod.GM.isPaused) UIManager.instance.TogglePauseGame();
             HeroController.instance.TakeHealth(9999);
             HeroController.instance.heroDeathPrefab.SetActive(true);
-            DebugMod.GM.ReadyForRespawn();
+            DebugMod.GM.ReadyForRespawn(false);
             GameCameras.instance.hudCanvas.gameObject.SetActive(false);
             GameCameras.instance.hudCanvas.gameObject.SetActive(true);
         }

--- a/Source/BindableFunctions.cs
+++ b/Source/BindableFunctions.cs
@@ -582,7 +582,7 @@ namespace DebugMod
             if (DebugMod.GM.isPaused) UIManager.instance.TogglePauseGame();
             HeroController.instance.TakeHealth(9999);
             HeroController.instance.heroDeathPrefab.SetActive(true);
-            DebugMod.GM.ReadyForRespawn(false);
+            DebugMod.GM.ReadyForRespawn();
             GameCameras.instance.hudCanvas.gameObject.SetActive(false);
             GameCameras.instance.hudCanvas.gameObject.SetActive(true);
         }

--- a/Source/Console.cs
+++ b/Source/Console.cs
@@ -70,10 +70,10 @@ namespace DebugMod
 
         public static void AddLine(string chatLine)
         {
-            while (history.Count > 1000)
-            {
-                history.RemoveAt(0);
-            }
+//            while (history.Count > 1000)
+//            {
+//                history.RemoveAt(0);
+//            }
 
             int wrap = WrapIndex(GUIController.Instance.arial, 13, chatLine);
 
@@ -103,6 +103,7 @@ namespace DebugMod
             try
             {
                 File.WriteAllLines("console.txt", history.ToArray());
+                Reset();
                 Console.AddLine("Written history to console.txt");
             }
             catch (Exception arg)

--- a/Source/Console.cs
+++ b/Source/Console.cs
@@ -70,10 +70,10 @@ namespace DebugMod
 
         public static void AddLine(string chatLine)
         {
-//            while (history.Count > 1000)
-//            {
-//                history.RemoveAt(0);
-//            }
+            while (history.Count > 1000)
+            {
+                history.RemoveAt(0);
+            }
 
             int wrap = WrapIndex(GUIController.Instance.arial, 13, chatLine);
 
@@ -103,7 +103,6 @@ namespace DebugMod
             try
             {
                 File.WriteAllLines("console.txt", history.ToArray());
-                Reset();
                 Console.AddLine("Written history to console.txt");
             }
             catch (Exception arg)

--- a/Source/DebugMod.cs
+++ b/Source/DebugMod.cs
@@ -104,6 +104,8 @@ namespace DebugMod
                 settings.binds.Add("Hide Hero", (int)KeyCode.Backspace);
                 settings.binds.Add("Take Screenshot", (int)KeyCode.KeypadEnter);
                 settings.binds.Add("Toggle Foreground Elements", (int)KeyCode.Keypad5);
+                settings.binds.Add("Show More Foreground Elements", (int)KeyCode.Keypad2);
+                settings.binds.Add("Show Fewer Foreground Elements", (int)KeyCode.Keypad8);
             }
 
             UnityEngine.SceneManagement.SceneManager.activeSceneChanged += LevelActivated;

--- a/Source/DebugMod.cs
+++ b/Source/DebugMod.cs
@@ -40,8 +40,10 @@ namespace DebugMod
         internal static bool noclip;
         internal static Vector3 noclipPos;
         internal static bool cameraFollow;
+        internal static bool showingFgObjs = true;
 
         internal static Dictionary<string, Pair> bindMethods = new Dictionary<string, Pair>();
+        internal static readonly Dictionary<int, float> PreviousAlphaValues = new Dictionary<int, float>();
 
         public override void Initialize()
         {
@@ -101,7 +103,7 @@ namespace DebugMod
                 settings.binds.Add("Toggle HUD", (int)KeyCode.Delete);
                 settings.binds.Add("Hide Hero", (int)KeyCode.Backspace);
                 settings.binds.Add("Take Screenshot", (int)KeyCode.KeypadEnter);
-                settings.binds.Add("Hide Foreground Elements", (int)KeyCode.Keypad5);
+                settings.binds.Add("Toggle Foreground Elements", (int)KeyCode.Keypad5);
             }
 
             UnityEngine.SceneManagement.SceneManager.activeSceneChanged += LevelActivated;
@@ -188,12 +190,14 @@ namespace DebugMod
                 PlayerDeathWatcher.Reset();
                 BossHandler.LookForBoss(sceneName);
             }
+
+            showingFgObjs = true;
+            PreviousAlphaValues.Clear();
         }
 
         private string OnLevelUnload(string toScene)
         {
             _unloadTime = Time.realtimeSinceStartup;
-
             return toScene;
         }
 

--- a/Source/DebugMod.cs
+++ b/Source/DebugMod.cs
@@ -172,9 +172,9 @@ namespace DebugMod
                 TimeSpan timeSpan = TimeSpan.FromSeconds(PlayerData.instance.playTime);
                 string text = string.Format("{0:00}.{1:00}", Math.Floor(timeSpan.TotalHours), timeSpan.Minutes);
                 int profileID = PlayerData.instance.profileID;
-                string saveFilename = GameManager.instance.GetSaveFilename(profileID);
-                DateTime lastWriteTime = File.GetLastWriteTime(Application.persistentDataPath + saveFilename);
-                Console.AddLine("New savegame loaded. Profile playtime " + text + " Completion: " + PlayerData.instance.completionPercentage + " Save slot: " + profileID + " Game Version: " + PlayerData.instance.version + " Last Written: " + lastWriteTime);
+                //string saveFilename = GameManager.instance.GetSaveFilename(profileID);
+                //DateTime lastWriteTime = File.GetLastWriteTime(Application.persistentDataPath + saveFilename);
+                Console.AddLine("New savegame loaded. Profile playtime " + text + " Completion: " + PlayerData.instance.completionPercentage + " Save slot: " + profileID + " Game Version: " + PlayerData.instance.version);// + " Last Written: " + lastWriteTime);
 
                 _loadingChar = false;
             }

--- a/Source/DebugMod.cs
+++ b/Source/DebugMod.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Linq;
@@ -101,6 +100,8 @@ namespace DebugMod
                 settings.binds.Add("Reset Camera Zoom", (int)KeyCode.End);
                 settings.binds.Add("Toggle HUD", (int)KeyCode.Delete);
                 settings.binds.Add("Hide Hero", (int)KeyCode.Backspace);
+                settings.binds.Add("Take Screenshot", (int)KeyCode.KeypadEnter);
+                settings.binds.Add("Hide Foreground Elements", (int)KeyCode.Keypad5);
             }
 
             UnityEngine.SceneManagement.SceneManager.activeSceneChanged += LevelActivated;

--- a/Source/DebugMod.cs
+++ b/Source/DebugMod.cs
@@ -177,9 +177,9 @@ namespace DebugMod
                 TimeSpan timeSpan = TimeSpan.FromSeconds(PlayerData.instance.playTime);
                 string text = string.Format("{0:00}.{1:00}", Math.Floor(timeSpan.TotalHours), timeSpan.Minutes);
                 int profileID = PlayerData.instance.profileID;
-                //string saveFilename = GameManager.instance.GetSaveFilename(profileID);
-                //DateTime lastWriteTime = File.GetLastWriteTime(Application.persistentDataPath + saveFilename);
-                Console.AddLine("New savegame loaded. Profile playtime " + text + " Completion: " + PlayerData.instance.completionPercentage + " Save slot: " + profileID + " Game Version: " + PlayerData.instance.version);// + " Last Written: " + lastWriteTime);
+                string saveFilename = GameManager.instance.GetSaveFilename(profileID);
+                DateTime lastWriteTime = File.GetLastWriteTime(Application.persistentDataPath + saveFilename);
+                Console.AddLine("New savegame loaded. Profile playtime " + text + " Completion: " + PlayerData.instance.completionPercentage + " Save slot: " + profileID + " Game Version: " + PlayerData.instance.version + " Last Written: " + lastWriteTime);
 
                 _loadingChar = false;
             }
@@ -200,6 +200,7 @@ namespace DebugMod
         private string OnLevelUnload(string toScene)
         {
             _unloadTime = Time.realtimeSinceStartup;
+
             return toScene;
         }
 


### PR DESCRIPTION
## What's this?

This PR adds hotkeys to hide elements in the foreground (toggleable) and to adjust how far in the foreground an element must be to be hidden.

## Why?

For screenshots, mainly.  Often decorative foreground elements will obscure details in the scene.

For example, in the Stag Nest, this is the normal view:

![toggle_show](https://user-images.githubusercontent.com/6389719/47946858-17549c00-dee8-11e8-87b2-37114d99eaeb.png)

But you can view/capture additional details by hiding the foreground elements:

![toggle_hide](https://user-images.githubusercontent.com/6389719/47946862-2f2c2000-dee8-11e8-9804-fdcd835e649e.png)

The default distance at which elements are hidden is not always ideal for the area you're in, though, so you can also adjust that distance to suit your preference.

![adjust1](https://user-images.githubusercontent.com/6389719/47946879-626eaf00-dee8-11e8-83c7-e1dfb1e3247e.png)
![adjust2](https://user-images.githubusercontent.com/6389719/47946880-639fdc00-dee8-11e8-9600-5c6605c23724.png)
![adjust3](https://user-images.githubusercontent.com/6389719/47946882-64d10900-dee8-11e8-93e8-821ebf1edb67.png)
![adjust4](https://user-images.githubusercontent.com/6389719/47946883-65699f80-dee8-11e8-9bf2-10c2e79c718a.png)

## Which keys?

The visibility toggle key is Keypad5, and the distance adjusting keys are Keypad2 and Keypad8 (pulling the threshold toward the camera or pushing it away, respectively).
